### PR TITLE
Update external downloads to released versions

### DIFF
--- a/SuperBuild/cmake/External-Catkin.cmake
+++ b/SuperBuild/cmake/External-Catkin.cmake
@@ -7,8 +7,8 @@ ExternalProject_Add(${_proj_name}
   STAMP_DIR         ${_SB_BINARY_DIR}/stamp
   #--Download step--------------
   DOWNLOAD_DIR      ${SB_DOWNLOAD_DIR}
-  URL               https://github.com/ros/catkin/archive/indigo-devel.zip
-  URL_MD5           f3085118b4327d470da881062e761569
+  URL               https://github.com/ros/catkin/archive/0.6.16.zip
+  URL_MD5           F5D45AE68709CE6E3346FB8C019416F8
   #--Update/Patch step----------
   UPDATE_COMMAND    ""
   #--Configure step-------------

--- a/SuperBuild/cmake/External-LAStools.cmake
+++ b/SuperBuild/cmake/External-LAStools.cmake
@@ -8,7 +8,7 @@ ExternalProject_Add(${_proj_name}
   #--Download step--------------
   DOWNLOAD_DIR      ${SB_DOWNLOAD_DIR}
   URL               http://lastools.org/download/LAStools.zip
-  URL_MD5           fc9800fd41158ad873d999a3a18e312e
+  URL_MD5           975ae0bc730697e3553b81bb61d34bb7
   #--Update/Patch step----------
   UPDATE_COMMAND    ""
   #--Configure step-------------

--- a/SuperBuild/cmake/External-LAStools.cmake
+++ b/SuperBuild/cmake/External-LAStools.cmake
@@ -8,7 +8,6 @@ ExternalProject_Add(${_proj_name}
   #--Download step--------------
   DOWNLOAD_DIR      ${SB_DOWNLOAD_DIR}
   URL               http://lastools.org/download/LAStools.zip
-  URL_MD5           975ae0bc730697e3553b81bb61d34bb7
   #--Update/Patch step----------
   UPDATE_COMMAND    ""
   #--Configure step-------------

--- a/SuperBuild/cmake/External-OpenSfM.cmake
+++ b/SuperBuild/cmake/External-OpenSfM.cmake
@@ -9,7 +9,7 @@ ExternalProject_Add(${_proj_name}
   #--Download step--------------
   DOWNLOAD_DIR      ${SB_DOWNLOAD_DIR}
   URL               https://github.com/mapillary/OpenSfM/archive/odm-2.zip
-  URL_MD5           4dd69ed84127dfe16d2215b1ebb7c977
+  URL_MD5           2D56E04D7130E7A9D266BDBAC0539C47
   #--Update/Patch step----------
   UPDATE_COMMAND    ""
   #--Configure step-------------


### PR DESCRIPTION
Catkin now downloads a release, OpenSfM and LASTools have a correct hash. OpenSfM should be constant, but LAStools is unversioned and will be difficult to deal with.

Note that we should be dropping LAStools support in the near future for something better. 
